### PR TITLE
ci: Change config to use the orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,12 +7,12 @@ workflows:
   test:
     jobs:
       - unity/test:
-          unity-license-var-name: "ACTIVATION_ULF_ENC"
+          unity-license-var-name: "ACTIVATION_ULF_ENC_2020"
           tag: "2020.1.0f1-linux-il2cpp-1"
           project-path: "src"
           test-platform: "playmode"
       - unity/build:
-          unity-license-var-name: "ACTIVATION_ULF_ENC"
+          unity-license-var-name: "ACTIVATION_ULF_ENC_2020"
           tag: "2020.1.0f1-linux-il2cpp-1"
           project-path: "src"
           build-target: StandaloneLinux64

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,70 +1,18 @@
 version: 2.1
-executors:
-  unity:
-    docker:
-      - image: gableroux/unity3d:2020.1.0a21
-commands:
-  activate:
-    steps:
-      - run:
-          name: "Activate Unity Licence File"
-          command: |
-            mkdir -p /root/.cache/unity3d
-            mkdir -p /root/.local/share/unity3d/Unity/
 
-            if [[ -z $"ACTIVATION_ULF_ENC" ]]; then
-              echo "ACTIVATION_ULF_ENC is missing. You must provide the base64 encoded  ULF licence file contents."
-              exit 1
-            fi
-
-            echo
-            echo "Decoding and writing licence file to /root/.local/share/unity3d/Unity/Unity_lic.ulf"
-            echo
-
-            cat $ACTIVATION_ULF_ENC | base64 --decode > /root/.local/share/unity3d/Unity/Unity_lic.ulf
-  run_tests:
-    steps:
-      - run:
-          name: Testing
-          command: |
-            set -x
-
-            echo "Testing for $TEST_PLATFORM"
-
-            ${UNITY_EXECUTABLE:-xvfb-run --auto-servernum --server-args='-screen 0 640x480x24' /opt/Unity/Editor/Unity} \
-              -projectPath $(pwd) \
-              -runTests \
-              -testPlatform $TEST_PLATFORM \
-              -testResults $(pwd)/$TEST_PLATFORM-results.xml \
-              -logFile /dev/stdout \
-              -batchmode
-
-            UNITY_EXIT_CODE=$?
-
-            if [ $UNITY_EXIT_CODE -eq 0 ]; then
-              echo "Run succeeded, no failures occurred";
-            elif [ $UNITY_EXIT_CODE -eq 2 ]; then
-              echo "Run succeeded, some tests failed";
-            elif [ $UNITY_EXIT_CODE -eq 3 ]; then
-              echo "Run failure (other failure)";
-            else
-              echo "Unexpected exit code $UNITY_EXIT_CODE";
-            fi
-
-            cat $(pwd)/$TEST_PLATFORM-results.xml | grep test-run | grep Passed
-            exit $UNITY_TEST_EXIT_CODE
-            
-jobs:
-  UnityTests:
-    executor: unity
-    steps:
-      - run:
-          name: Demo Unity
-          command: echo "First commit"
-      - activate
-      - run_tests
+orbs:
+  unity: ericribeiro/unity@dev:alpha
 
 workflows:
-  Unity_Test_Deploy:
+  test:
     jobs:
-      - UnityTests
+      - unity/test:
+          unity-license-var-name: "ACTIVATION_ULF_ENC"
+          tag: "2020.1.0f1-linux-il2cpp-1"
+          project-path: "src"
+          test-platform: "playmode"
+      - unity/build:
+          unity-license-var-name: "ACTIVATION_ULF_ENC"
+          tag: "2020.1.0f1-linux-il2cpp-1"
+          project-path: "src"
+          build-target: StandaloneLinux64

--- a/src/ProjectSettings/EditorBuildSettings.asset
+++ b/src/ProjectSettings/EditorBuildSettings.asset
@@ -4,5 +4,8 @@
 EditorBuildSettings:
   m_ObjectHideFlags: 0
   serializedVersion: 2
-  m_Scenes: []
+  m_Scenes:
+  - enabled: 1
+    path: Assets/Scenes/GameScreen.unity
+    guid: 4a2b4de43abf74343b61d0891b9250ff
   m_configObjects: {}


### PR DESCRIPTION
This PR exemplifies how the current iteration of the orb is used and how easily the demo project can be modified to use it.

It is important to notice the changes in `src/ProjectSettings/EditorBuildSettings.asset`. They mean that the test inside the project was enabled and is now visible to the `test` command. Without enabling it, no tests would be found, and nothing would run.

A green build with artifacts and test results can be found here: https://app.circleci.com/pipelines/github/EricRibeiro/Unity2D-Demo-Game-CI-CD/159/workflows/afe37e62-6f8c-4414-a8f5-835ac4753b18